### PR TITLE
Add pdf viewer page and link

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -260,6 +260,70 @@
   opacity: 0.6;
 }
 
+/* Portfolio link styles */
+.portfolio-link {
+  color: #4A90E2;
+  text-decoration: underline;
+  font-size: 1.125rem;
+  font-weight: 500;
+  transition: color 0.2s ease;
+  display: inline-block;
+  margin-top: 1rem;
+}
+
+.portfolio-link:hover {
+  color: rgba(74, 144, 226, 0.8);
+}
+
+/* Portfolio page styles */
+.portfolio-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.portfolio-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.portfolio-title {
+  font-size: 2.5rem;
+  font-weight: bold;
+  color: #333;
+  margin: 0;
+}
+
+.pdf-container {
+  width: 100%;
+  height: calc(100vh - 200px);
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
+  background-color: #f9f9f9;
+}
+
+.pdf-viewer {
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+/* Mobile responsiveness */
+@media (max-width: 768px) {
+  .portfolio-title {
+    font-size: 2rem;
+  }
+  
+  .pdf-container {
+    height: calc(100vh - 150px);
+  }
+  
+  .portfolio-link {
+    font-size: 1rem;
+  }
+}
+
 /* Password Modal Styles */
 .modal-overlay {
   position: fixed;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import { AnimatePresence } from 'framer-motion';
 import { Home } from './components/Home';
+import { Portfolio } from './components/Portfolio';
 import { ProjectDetail } from './components/ProjectDetail';
 import './App.css';
 
@@ -20,6 +21,7 @@ function App() {
             <Routes>
               <Route path="/" element={<Home />} />
               <Route path="/project/:id" element={<ProjectDetail />} />
+              <Route path="/portfolio" element={<Portfolio />} />
             </Routes>
           </AnimatePresence>
         </main>

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -53,6 +53,7 @@ export const Home = () => {
         <div className="home-text">
           <h1 className="home-title">Rongze is an innovative UX Designer and Developer base in London.</h1>
           <p className="home-description">I find great joy in solving problems for others.</p>
+          <Link to="/portfolio" className="portfolio-link">View portfolio</Link>
         </div>
         <div className="profile-image">
           <img src="/images/profile.jpg" alt="Profile" />

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -1,0 +1,19 @@
+import { motion } from 'framer-motion';
+import { pageTransition } from '../utils/animations';
+
+export const Portfolio = () => {
+  return (
+    <motion.div {...pageTransition} className="portfolio-container">
+      <div className="portfolio-header">
+        <h1 className="portfolio-title">Portfolio</h1>
+      </div>
+      <div className="pdf-container">
+        <iframe
+          src="/portfolio.pdf"
+          title="Portfolio PDF"
+          className="pdf-viewer"
+        />
+      </div>
+    </motion.div>
+  );
+};


### PR DESCRIPTION
Add a portfolio PDF viewer page, accessible via a new route and a link on the home page.

---
<a href="https://cursor.com/background-agent?bcId=bc-024db128-abc9-4f74-9ad2-9c606418dfe0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-024db128-abc9-4f74-9ad2-9c606418dfe0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

